### PR TITLE
local_settings.pyの生成方法の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ### local_settings.pyを作成(すでに作成済みの場合は不要)
 クローンしたディレクトリに移動し、SECRET_KEYを生成するスクリプトを実行する。これによりSECRET_KEYが書き込まれたlocal_settings.pyが作成される。
 ```
-$ docker-compose run web python3 generate_secretkey.py > local_settings.py
+$ docker-compose run web python3 generate_secretkey.py
 ```
 
 ### コンテナを起動する

--- a/generate_secretkey.py
+++ b/generate_secretkey.py
@@ -1,5 +1,7 @@
 from django.core.management.utils import get_random_secret_key
 
 secret_key = get_random_secret_key()
-text = "SECRET_KEY = '{}'".format(secret_key)
-print(text)
+text = "SECRET_KEY = '{}'\n".format(secret_key)
+file = open('local_settings.py', 'w', encoding='UTF-8')
+
+file.write(text)


### PR DESCRIPTION
SECRET_KEYだけを書き込むはずが、ターミナルのログを全て書き込む仕様になっていたため、修正。
また、print()で標準出力させる方法はWindows環境では文字コードの問題が発生するため避けた方が良い。
文字コードの問題もencodingを指定することで解消。